### PR TITLE
Update for dynamic Sonic Pi port

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A simple command line interface for Sonic Pi, written in Ruby.
 
 **Requires Sonic Pi v2.7 or higher**.
 
+ver 0.1.3 allows compatibility with Sonic Pi v3.2: tested on Linux, Raspberry Pi and Windows
+
 Installation
 -------
 
@@ -45,4 +47,4 @@ Alternatives
 
 Thanks to Sam Aaron for creating Sonic Pi. Official command line support is planned for Sonic Pi 3.0.
 
-For those interested, the code weighs in at around 100 lines and is stupid simple. Take a look.
+For those interested, the code weighs in at around 120 lines and is stupid simple. Take a look.

--- a/bin/sonic_pi
+++ b/bin/sonic_pi
@@ -1,62 +1,47 @@
-#!/usr/bin/env ruby
+require 'socket'
+require 'rubygems'
+require 'osc-ruby'
+require 'securerandom'
 
-require 'sonic_pi'
+class SonicPi
+  def initialize(port=4557)
+    @port=port
+  end
 
-def stdin
-  unless STDIN.tty?
-    $stdin.read
+  RUN_COMMAND = "/run-code"
+  STOP_COMMAND = "/stop-all-jobs"
+  SERVER = 'localhost'
+  #PORT = 4557
+  GUI_ID = 'SONIC_PI_CLI'
+  
+
+
+  def run(command)
+    send_command(RUN_COMMAND, command)
+  end
+
+  def stop
+    send_command(STOP_COMMAND)
+  end
+
+  def test_connection!
+    begin
+      socket = UDPSocket.new
+      socket.bind(nil, @port)
+      abort("ERROR: Sonic Pi is not listening on #{@port} - is it running?")
+    rescue
+      # everything is good
+    end
+  end
+
+  private
+
+  def client
+    @client ||= OSC::Client.new(SERVER, @port)
+  end
+
+  def send_command(call_type, command=nil)
+    prepared_command = OSC::Message.new(call_type, GUI_ID, command)
+    client.send(prepared_command)
   end
 end
-
-def args
-  ARGV.join(' ')
-end
-
-def args_and_stdin
-  @args_and_stdin ||= [
-    args,
-    stdin,
-  ].join("\n").strip
-end
-
-def print_help
-  puts <<-HELP
-sonic-pi-cli
-
-Usage:
-  sonic_pi <code>
-  sonic_pi stop
-  cat music.rb | sonic_pi
-  sonic_pi --help
-
-Sonic Pi must be running for this utility to work.
-You can pipe code to stdin to execute it.
-
-Options:
-  <code>  Run the given code.
-  stop    Stop all running music.
-  --help  Display this text.
-
-Made by Nick Johnstone (github.com/Widdershin/sonic-pi-cli).
-Thanks to Sam Aaron for creating Sonic Pi.
-HELP
-end
-
-def run
-  app = SonicPi.new
-
-  case args_and_stdin
-  when '--help', '-h', ''
-    print_help
-  when 'stop'
-    app.test_connection!
-
-    app.stop
-  else
-    app.test_connection!
-
-    app.run(args_and_stdin)
-  end
-end
-
-run

--- a/lib/sonic_pi.rb
+++ b/lib/sonic_pi.rb
@@ -1,41 +1,77 @@
-require 'socket'
-require 'rubygems'
-require 'osc-ruby'
-require 'securerandom'
+#!/usr/bin/env ruby
 
-class SonicPi
-  RUN_COMMAND = "/run-code"
-  STOP_COMMAND = "/stop-all-jobs"
-  SERVER = 'localhost'
-  PORT = 4557
-  GUI_ID = 'SONIC_PI_CLI'
+require "sonic_pi.rb"
 
-  def run(command)
-    send_command(RUN_COMMAND, command)
-  end
-
-  def stop
-    send_command(STOP_COMMAND)
-  end
-
-  def test_connection!
-    begin
-      socket = UDPSocket.new
-      socket.bind(nil, PORT)
-      abort("ERROR: Sonic Pi is not listening on #{PORT} - is it running?")
-    rescue
-      # everything is good
-    end
-  end
-
-  private
-
-  def client
-    @client ||= OSC::Client.new(SERVER, PORT)
-  end
-
-  def send_command(call_type, command=nil)
-    prepared_command = OSC::Message.new(call_type, GUI_ID, command)
-    client.send(prepared_command)
+def stdin
+  unless STDIN.tty?
+    $stdin.read
   end
 end
+
+def pvalue #get current listen port for Sonic Pi from log file
+  value= 4557 #pre new logfile format port was always 4557
+  File.open(ENV['HOME']+'/.sonic-pi/log/server-output.log','r') do |f1|
+    while l = f1.gets
+      if l.include?"Listen port:"
+        value = l.split(" ").last.to_i
+        break
+      end
+    end
+    f1.close
+  end
+  return value
+end
+
+def args
+  args=ARGV.join(' ')
+end
+
+def args_and_stdin
+  @args_and_stdin ||= [
+    args,
+    stdin,
+  ].join("\n").strip
+end
+
+def print_help
+  puts <<-HELP
+sonic-pi-cli
+
+Usage:
+  sonic_pi -p<port no> <code>
+  sonic_pi -p<port no> stop
+  cat music.rb | sonic_pi -p<port no>
+  sonic_pi --help
+
+Sonic Pi must be running for this utility to work.
+You can pipe code to stdin to execute it.
+
+Options:
+  <code>  Run the given code.
+  stop    Stop all running music.
+  --help  Display this text.
+
+Made by Nick Johnstone (github.com/Widdershin/sonic-pi-cli).
+Thanks to Sam Aaron for creating Sonic Pi.
+HELP
+end
+  
+def run
+
+  app = SonicPi.new(pvalue) #pass in port value
+  
+  case args_and_stdin
+  when '--help', '-h', ''
+    print_help
+  when 'stop'
+    app.test_connection!
+    app.stop
+  else
+
+    app.test_connection!
+
+    app.run(args_and_stdin)
+  end
+end
+
+run

--- a/sonic-pi-cli.gemspec
+++ b/sonic-pi-cli.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'sonic-pi-cli'
-  s.version     = '0.1.1'
-  s.date        = '2016-11-10'
+  s.version     = '0.1.3'
+  s.date        = '2019-08-26'
   s.summary     = "Sonic Pi CLI"
   s.description = "A simple command line interface for Sonic Pi"
   s.authors     = ["Nick Johnstone"]


### PR DESCRIPTION
These changes allow for the dynamically allocated Listen port used in Sonic Pi 3.2dev
Previous version of Sonic Pi all used port 4557, but this is no longer the case.
These changes read the port in used from the Sonic Pi server-output.log and use it
to initialise sonic-pi-cli