### PR TITLE
Update for dynamic port allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A simple command line interface for Sonic Pi, written in Ruby.
 
 **Requires Sonic Pi v2.7 or higher**.
 
+ver 0.1.3 allows compatibility with Sonic Pi v3.2: tested on Linux, Raspberry Pi and Windows
+
 Installation
 -------
 
@@ -45,4 +47,4 @@ Alternatives
 
 Thanks to Sam Aaron for creating Sonic Pi. Official command line support is planned for Sonic Pi 3.0.
 
-For those interested, the code weighs in at around 100 lines and is stupid simple. Take a look.
+For those interested, the code weighs in at around 120 lines and is stupid simple. Take a look.

--- a/bin/sonic_pi
+++ b/bin/sonic_pi
@@ -8,6 +8,20 @@ def stdin
   end
 end
 
+def pvalue #get current listen port for Sonic Pi from log file
+  value= 4557 #pre new logfile format port was always 4557
+  File.open(ENV['HOME']+'/.sonic-pi/log/server-output.log','r') do |f1|
+    while l = f1.gets
+      if l.include?"Listen port:"
+        value = l.split(" ").last.to_i
+        break
+      end
+    end
+    f1.close
+  end
+  return value
+end
+
 def args
   ARGV.join(' ')
 end
@@ -28,7 +42,7 @@ Usage:
   sonic_pi stop
   cat music.rb | sonic_pi
   sonic_pi --help
-
+ 
 Sonic Pi must be running for this utility to work.
 You can pipe code to stdin to execute it.
 
@@ -43,8 +57,8 @@ HELP
 end
 
 def run
-  app = SonicPi.new
-
+  app = SonicPi.new(pvalue) #pass in port value
+ 
   case args_and_stdin
   when '--help', '-h', ''
     print_help

--- a/lib/sonic_pi.rb
+++ b/lib/sonic_pi.rb
@@ -4,11 +4,16 @@ require 'osc-ruby'
 require 'securerandom'
 
 class SonicPi
+  def initialize(port=4557)
+    @port=port
+  end
+
   RUN_COMMAND = "/run-code"
   STOP_COMMAND = "/stop-all-jobs"
   SERVER = 'localhost'
-  PORT = 4557
   GUI_ID = 'SONIC_PI_CLI'
+  
+
 
   def run(command)
     send_command(RUN_COMMAND, command)
@@ -21,8 +26,8 @@ class SonicPi
   def test_connection!
     begin
       socket = UDPSocket.new
-      socket.bind(nil, PORT)
-      abort("ERROR: Sonic Pi is not listening on #{PORT} - is it running?")
+      socket.bind(nil, @port)
+      abort("ERROR: Sonic Pi is not listening on #{@port} - is it running?")
     rescue
       # everything is good
     end
@@ -31,7 +36,7 @@ class SonicPi
   private
 
   def client
-    @client ||= OSC::Client.new(SERVER, PORT)
+    @client ||= OSC::Client.new(SERVER, @port)
   end
 
   def send_command(call_type, command=nil)

--- a/sonic-pi-cli.gemspec
+++ b/sonic-pi-cli.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'sonic-pi-cli'
-  s.version     = '0.1.1'
-  s.date        = '2016-11-10'
+  s.version     = '0.1.3'
+  s.date        = '2019-08-26'
   s.summary     = "Sonic Pi CLI"
   s.description = "A simple command line interface for Sonic Pi"
   s.authors     = ["Nick Johnstone"]


### PR DESCRIPTION
Sonic Pi 3.2dev introduces using a dynamically allocated port commands from the GUI. This breaks sonic-pi-cli which assumes the previously used port 4557.
This update reads the dynamically allocated port from the Sonic Pi server-output.log and uses it to initialise the port used by sonic-pi-cli. If there is no port specified, it reverts to using the previous static port 4557 used in previous versions of Sonic Pi.
The changes have been tested on Mac, Windows PC and Raspberry Pi, and should also be fine on Linux versions of Sonic Pi.